### PR TITLE
[PHAnimatedImage] Guard imageRef

### DIFF
--- a/PHImageKit/PHAnimatedImage.swift
+++ b/PHImageKit/PHAnimatedImage.swift
@@ -134,8 +134,11 @@ public class PHAnimatedImage: UIImage {
     }
 
     private func predrawnImageAtIndex(index:Int) -> UIImage {
-        let imageRef = CGImageSourceCreateImageAtIndex(imageSource!, index, nil)
-        return UIImage(CGImage: imageRef!).ik_decompress()
+        guard let imageRef = CGImageSourceCreateImageAtIndex(imageSource!, index, nil) else {
+            return UIImage()
+        }
+
+        return UIImage(CGImage: imageRef).ik_decompress()
     }
 
     private func frameIndexesToCache(index:Int) -> NSMutableIndexSet {


### PR DESCRIPTION
## Scope

- [x] ImageRef can be `nil` when `ImageIO` fails `malformed GIF`
